### PR TITLE
Highlight code in the notebook cells of the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
-    'sphinx.ext.intersphinx'
+    'sphinx.ext.intersphinx',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting'
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,10 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
-    'sphinx.ext.intersphinx']
+    'sphinx.ext.intersphinx'
+    'IPython.sphinxext.ipython_directive',
+    'IPython.sphinxext.ipython_console_highlighting'
+]
 
 nbsphinx_execute = 'auto'
 


### PR DESCRIPTION
Hello @me-manu,

The cells in the jupyter notebook used in the docs do not have any syntax highlight (e.g. [here](https://gammaalps.readthedocs.io/en/latest/tutorials/mixing_single_cell.html) or any other of the notebook tutorials).
This PR should allow syntax highlight in such notebook cells.
It will improve readability, I think.

Cheers,
Cosimo