### PR TITLE
changed requirements for RTD to fix broken docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ scipy>=1.5
 numba>=0.51
 astropy>=4.0
 ebltable>=0.2
-nbsphinx==0.7.1
+nbsphinx>=0.8.5
 sphinx
 sphinx-astropy
 ipython

--- a/docs/tutorials/accessing_GMF_components.ipynb
+++ b/docs/tutorials/accessing_GMF_components.ipynb
@@ -123,7 +123,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x160d0cf10>"
+       "<matplotlib.colorbar.Colorbar at 0x158df8910>"
       ]
      },
      "execution_count": 6,
@@ -195,7 +195,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x1616248b0>"
+       "<matplotlib.colorbar.Colorbar at 0x159223e50>"
       ]
      },
      "execution_count": 9,
@@ -307,7 +307,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x1620a5310>"
+       "<matplotlib.colorbar.Colorbar at 0x159ca9df0>"
       ]
      },
      "execution_count": 13,
@@ -362,7 +362,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x1626d7b20>"
+       "<matplotlib.colorbar.Colorbar at 0x15a2df910>"
       ]
      },
      "execution_count": 15,
@@ -417,7 +417,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x162e79190>"
+       "<matplotlib.colorbar.Colorbar at 0x15aa851f0>"
       ]
      },
      "execution_count": 17,


### PR DESCRIPTION
Creating the docs on RTD fails with error 
```
'nbformat.notebooknode.NotebookNode object' has no attribute 'tags'
```
which is related to the nbsphinx issue https://github.com/spatialaudio/nbsphinx/issues/563 

Trying to fix this by requiring nbshinx >= 0.8.5, otherwise, pin jinja version. 